### PR TITLE
Prevent container crash loops when wireguard is buried in dmesg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,6 @@ CMD ["/entrypoint.sh"]
 ENV TS_STATE_DIR "/var/lib/tailscale"
 ENV TS_SOCKET "/var/run/tailscale/tailscaled.sock"
 ENV TS_EXTRA_ARGS "--reset"
+ENV TS_AUTH_ONCE "true"
 
 ENV REQUIRE_AUTH_KEY "false"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,8 @@ fi
 # load the kernel module if it exists
 if modprobe wireguard 2>/dev/null
 then
-    dmesg | grep wireguard
+    modinfo wireguard || true
+    dmesg | grep wireguard || true
     export TS_USERSPACE="${TS_USERSPACE:-false}"
 fi
 


### PR DESCRIPTION
This would happen when a device has been online for a while and tried to recreate the tailscale container.

Change-type: patch