### PR TITLE
Restore iptables-legacy package not present in alpine 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN VERSION_SHORT=$(git describe --tags --abbrev=0 | sed 's/^v//') && \
 FROM alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache ca-certificates iptables iproute2 ip6tables
+RUN apk add --no-cache ca-certificates iptables iproute2 ip6tables iptables-legacy
 
 # Alpine 3.19 replaces legacy iptables with nftables based implementation.  We
 # can't be certain that all hosts that run Tailscale containers currently


### PR DESCRIPTION
Resolves: https://github.com/klutchell/balena-tailscale/issues/187