### PR TITLE
README: Update docker-compose to show restart: always

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ services:
     # where <arch> is one of aarch64, armv7hf or amd64
     image: bh.cr/gh_klutchell/tailscale-<arch>
     network_mode: host
-    restart: on-failure
+    restart: always
     volumes:
       - ts-state:/var/lib/tailscale
     labels:


### PR DESCRIPTION
When trying this out on our Balena edge device, I was getting:
```
Apr 11 00:55:43 f092329 d96fedde1270[2206]: boot: 2026/04/11 00:55:43 Sending SIGTERM to tailscaled
Apr 11 00:55:43 f092329 d96fedde1270[2206]: tailscaled got signal terminated; shutting down
Apr 11 00:55:43 f092329 d96fedde1270[2206]: boot: 2026/04/11 00:55:43 tailscaled exited
Apr 11 00:56:35 f092329 d96fedde1270[2185]: boot: 2026/04/11 00:56:35 Starting tailscaled
```
which got traced by Alex Gonzalez of Balena Support to be the following:
```
Hi, the boot prefix in the logs is actually tailscale's containerboot process
(https://github.com/tailscale/tailscale/blob/4fcce6000d3d3f79d1ac1fca571a50efb059cbf2/cmd/containerboot/main.go#L175).

The kill loop was triggered by containerboot detecting that tailscaled
couldn't maintain connectivity to the control plane (probably TCP timeouts to
104.18.x.x:443), causing it to cycle the daemon. This resolves eventually by
itself when connectivity is available.
```

However, on my edge device, since it was not shutting down on failure, tailscaled would not restart. By changing the default to be restart: always, this problem went away.